### PR TITLE
[MISC] Define LockQueryBuilder missing funcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 ## Unreleased
 ### Added
+- Lock fetching method to LockQueryBuilder classes.
 - Instance-promote method to ClusterClient class.
 - Instance-rejoin method to ClusterClient class.
 - Instance-check method to ClusterClient class.

--- a/src/mysql_shell/builders/locking/base.py
+++ b/src/mysql_shell/builders/locking/base.py
@@ -13,6 +13,11 @@ class BaseLockingQueryBuilder(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def build_fetch_acquired_query(self, task: str) -> str:
+        """Builds the acquired lock check query."""
+        raise NotImplementedError()
+
+    @abstractmethod
     def build_acquire_query(self, task: str, instance: str) -> str:
         """Builds the lock acquiring query."""
         raise NotImplementedError()

--- a/src/mysql_shell/builders/locking/charm.py
+++ b/src/mysql_shell/builders/locking/charm.py
@@ -50,6 +50,16 @@ class CharmLockingQueryBuilder(BaseLockingQueryBuilder):
             *insert_queries,
         ))
 
+    def build_fetch_acquired_query(self, task: str) -> str:
+        """Builds the acquired lock fetch query."""
+        query = "SELECT executor FROM {table} WHERE task = {task} AND status = {status}"
+
+        return query.format(
+            table=self._table,
+            task=self._quoter.quote_value(task),
+            status=self._quoter.quote_value("in-progress"),
+        )
+
     def build_acquire_query(self, task: str, instance: str) -> str:
         """Builds the lock acquiring query."""
         if task not in self.TASKS:


### PR DESCRIPTION
This PR adds the following functions to the `LockingQueryBuilder` class:

- `build_fetch_acquired_query`.