### PR TITLE
[MISC] Define BaseExecutor init method

### DIFF
--- a/src/mysql_shell/executors/base.py
+++ b/src/mysql_shell/executors/base.py
@@ -10,11 +10,15 @@ from ..models import ConnectionDetails
 class BaseExecutor(ABC):
     """Base class for all MySQL Shell executors."""
 
+    def __init__(self, conn_details: ConnectionDetails, shell_path: str):
+        """Initialize the executor."""
+        self._conn_details = conn_details
+        self._shell_path = shell_path
+
     @property
-    @abstractmethod
     def connection_details(self) -> ConnectionDetails:
         """Return the connection details."""
-        raise NotImplementedError()
+        return self._conn_details
 
     @abstractmethod
     def check_connection(self) -> None:

--- a/src/mysql_shell/executors/local.py
+++ b/src/mysql_shell/executors/local.py
@@ -14,8 +14,7 @@ class LocalExecutor(BaseExecutor):
 
     def __init__(self, conn_details: ConnectionDetails, shell_path: str):
         """Initialize the executor."""
-        self._conn_details = conn_details
-        self._shell_path = shell_path
+        super().__init__(conn_details, shell_path)
 
     def _common_args(self) -> list[str]:
         """Return the list of common arguments."""
@@ -38,11 +37,6 @@ class LocalExecutor(BaseExecutor):
                 f"--port={self._conn_details.port}",
                 f"--user={self._conn_details.username}",
             ]
-
-    @property
-    def connection_details(self) -> ConnectionDetails:
-        """Return the connection details."""
-        return self._conn_details
 
     @staticmethod
     def _parse_output(output: str) -> str | dict:


### PR DESCRIPTION
This PR moves the initialization method of the `LocalExecutor` class to the `BaseExecutor` one. This is needed so that we can type-check, to the best of our ability, the arguments passed to every single base-class children.