### PR TITLE
[MISC] Define ClusterClient missing funcs (II)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 
 ## Unreleased
+### Added
+- Fetch cluster-primary method to ClusterClient class.
+
 ## [0.5.1][changes-0.5.1] - 2025-12-18
 ### Fixed
 - Instance-label fetching within InstanceClient class.

--- a/src/mysql_shell/clients/cluster.py
+++ b/src/mysql_shell/clients/cluster.py
@@ -45,6 +45,23 @@ class MySQLClusterClient:
             logger.error(f"Failed to destroy cluster {cluster_name}")
             raise
 
+    def fetch_cluster_primary(self) -> str:
+        """Fetches an InnoDB cluster primary."""
+        command = "\n".join((
+            "shell.connect_to_primary()",
+            "host = str(shell.parse_uri(session.uri)['host'])",
+            "port = str(shell.parse_uri(session.uri)['port'])",
+            "print(host + ':' + port)",
+        ))
+
+        try:
+            result = self._executor.execute_py(command)
+        except ExecutionError:
+            logger.error("Failed to fetch cluster primary")
+            raise
+        else:
+            return result
+
     def fetch_cluster_status(self, cluster_name: str, extended: bool = False) -> dict:
         """Fetches an InnoDB cluster status."""
         command = "\n".join((

--- a/tests/clients/test_cluster.py
+++ b/tests/clients/test_cluster.py
@@ -44,6 +44,11 @@ class TestClusterClient:
         host = rows[0]["address"]
         return host
 
+    def test_fetch_cluster_primary(self, client: MySQLClusterClient):
+        """Test the fetching of the cluster primary."""
+        address = client.fetch_cluster_primary()
+        assert address == "0.0.0.0:3306"
+
     def test_fetch_cluster_status(self, client: MySQLClusterClient):
         """Test the fetching of the cluster status."""
         status = client.fetch_cluster_status(TEST_CLUSTER_NAME)


### PR DESCRIPTION
This PR adds the following functions to the `MySQLClusterClient` class:

- `fetch_cluster_primary`.