### PR TITLE
[MISC] Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 
 ## Unreleased
+
+## [0.6.0][changes-0.6.0] - 2026-01-12
 ### Added
 - Logging query builder class.
 ### Fixed
@@ -80,5 +82,6 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 [changes-0.4.2]: https://github.com/canonical/mysql-shell-client/compare/0.4.1...0.4.2
 [changes-0.5.0]: https://github.com/canonical/mysql-shell-client/compare/0.4.2...0.5.0
 [changes-0.5.1]: https://github.com/canonical/mysql-shell-client/compare/0.5.0...0.5.1
+[changes-0.6.0]: https://github.com/canonical/mysql-shell-client/compare/0.5.1...0.6.0
 [docs-changelog]: https://keepachangelog.com/en/1.0.0/
 [docs-semver]: https://semver.org/spec/v2.0.0.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Python client for MySQL Shell"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 readme = "README.md"
-version = "0.5.1"
+version = "0.6.0"
 authors = [
     { name = "Sinclert Perez", email = "sinclert.perez@canonical.com" }
 ]


### PR DESCRIPTION
This PR makes the necessary changes to release version 0.6.0.

Depends on https://github.com/canonical/mysql-shell-client/pull/24 & https://github.com/canonical/mysql-shell-client/pull/26.