### PR TITLE
[FIX] ensure catch all query for empty string value

### DIFF
--- a/src/mysql_shell/clients/instance.py
+++ b/src/mysql_shell/clients/instance.py
@@ -400,12 +400,10 @@ class MySQLInstanceClient:
 
         if not roles:
             roles = list(InstanceRole)
-            roles_filter = "(member_role IN ({roles}) OR member_role IS NULL OR member_role = '')"
+            roles_filter = "(member_role IN ({roles}) OR member_role = '')"
         if not states:
             states = list(InstanceState)
-            states_filter = (
-                "(member_state IN ({states}) OR member_state IS NULL OR member_state = '')"
-            )
+            states_filter = "(member_state IN ({states}) OR member_state = '')"
 
         query = (
             "SELECT member_id "


### PR DESCRIPTION
The [test](https://github.com/canonical/mysql-operators/actions/runs/21879145885/job/63303870093) will keep on failing if when testing for units added to cluster regardless of state/role isn't set.

Property [only_one_cluster_node_thats_uninitialized](https://github.com/canonical/mysql-operators/blob/fc2159a6c52eee2d37e6e55aa831f6e389caf0ef/machines/lib/charms/mysql/v0/mysql.py#L740) will never evaluate to true due state/role never matching the query, as non-set values are not `NULL`, but empty strings.

Result is that the [treatment](https://github.com/canonical/mysql-operators/blob/8a184b5386455564df08e55005fc6e7f5e77a993/kubernetes/src/charm.py#L888) for the said test will never trigger.

