### PR TITLE
[MISC] Spawn MySQL cluster before testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,31 +79,29 @@ jobs:
       MYSQL_USERNAME: root
       MYSQL_PASSWORD: root_pass
       MYSQL_SHELL_PATH: mysqlsh
-    services:
-      mysql:
-        image: mysql:${{ matrix.server.version }}
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
-          MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_PASSWORD }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v6
+      - name: "Set up Compose"
+        uses: docker/setup-compose-action@v1
+      - name: "Set up Python"
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
       - name: "Install binaries"
         run: |
           sudo add-apt-repository ppa:${{ matrix.shell.archive }}
           sudo apt update
           sudo apt install mysql-shell=${{ matrix.shell.version }}
-      - name: "Set up Python"
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
       - name: "Install poetry & tox"
         run: |
           pipx install poetry
           pipx install tox
+      - name: "Start services"
+        run: docker compose -f compose/mysql-${{ matrix.server.version }}.yaml up --wait
       - name: "Run tests"
         run: tox run -e integration
+      - name: "Stop services"
+        run: docker compose -f compose/mysql-${{ matrix.server.version }}.yaml down
       - name: "Upload Coverage to Codecov"
         uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ export MYSQL_USERNAME="root"
 export MYSQL_PASSWORD="root_pass"
 export MYSQL_SHELL_PATH="mysqlsh"
 
-podman-compose -f compose/mysql-8.0.yaml up --detach && tox -e integration
-podman-compose -f compose/mysql-8.0.yaml down
+sudo --preserve-env docker compose -f compose/mysql-8.0.yaml up --wait && tox -e integration
+sudo --preserve-env docker compose -f compose/mysql-8.0.yaml down
 ```
 
 ### Release

--- a/compose/mysql-8.0.yaml
+++ b/compose/mysql-8.0.yaml
@@ -2,11 +2,38 @@ name: "mysql-8.0"
 
 services:
 
-  mysql:
-    image: docker.io/mysql:8.0
-    platform: linux/amd64
-    ports:
-      - "3306:3306"
+  mysql-1:
+    image: "docker.io/mysql:8.0"
+    platform: "linux/amd64"
+    network_mode: "host"
+    command:
+      - --server-id=1
+      - --port=3306
+      - --binlog-transaction-dependency-tracking=WRITESET
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
+
+  mysql-2:
+    image: "docker.io/mysql:8.0"
+    platform: "linux/amd64"
+    network_mode: "host"
+    command:
+      - --server-id=2
+      - --port=3307
+      - --binlog-transaction-dependency-tracking=WRITESET
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
+
+  mysql-3:
+    image: "docker.io/mysql:8.0"
+    platform: "linux/amd64"
+    network_mode: "host"
+    command:
+      - --server-id=3
+      - --port=3308
+      - --binlog-transaction-dependency-tracking=WRITESET
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}

--- a/compose/mysql-8.4.yaml
+++ b/compose/mysql-8.4.yaml
@@ -2,11 +2,35 @@ name: "mysql-8.4"
 
 services:
 
-  mysql:
-    image: docker.io/mysql:8.4
-    platform: linux/amd64
-    ports:
-      - "3306:3306"
+  mysql-1:
+    image: "docker.io/mysql:8.4"
+    platform: "linux/amd64"
+    network_mode: "host"
+    command:
+      - --server-id=1
+      - --port=3306
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
+
+  mysql-2:
+    image: "docker.io/mysql:8.4"
+    platform: "linux/amd64"
+    network_mode: "host"
+    command:
+      - --server-id=2
+      - --port=3307
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
+
+  mysql-3:
+    image: "docker.io/mysql:8.4"
+    platform: "linux/amd64"
+    network_mode: "host"
+    command:
+      - --server-id=3
+      - --port=3308
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}

--- a/tests/clients/conftest.py
+++ b/tests/clients/conftest.py
@@ -7,7 +7,9 @@ from contextlib import suppress
 import pytest
 
 from ..helpers import (
+    TEST_CLUSTER_HOST,
     TEST_CLUSTER_NAME,
+    TEST_CLUSTER_PORT,
     build_local_executor,
 )
 
@@ -19,20 +21,29 @@ _GTID_MODES_ORDERED = (
 )
 
 
-@pytest.fixture(scope="session", autouse=True)
-def initialize_cluster():
-    """Initializes InnoDB cluster in an idempotent way."""
+def _create_cluster() -> None:
+    """Creates InnoDB cluster."""
     executor = build_local_executor(
         username=os.environ["MYSQL_USERNAME"],
         password=os.environ["MYSQL_PASSWORD"],
+        host=TEST_CLUSTER_HOST,
+        port=TEST_CLUSTER_PORT,
     )
 
-    # This variable is MySQL 8.0 specific
     with suppress(Exception):
-        executor.execute_sql("SET @@GLOBAL.binlog_transaction_dependency_tracking = 'WRITESET'")
+        executor.execute_py(f"dba.create_cluster('{TEST_CLUSTER_NAME}')")
+
+
+def _config_instance(instance_address: str, instance_port: str) -> None:
+    """Configs as instance before joining a InnoDB cluster."""
+    executor = build_local_executor(
+        username=os.environ["MYSQL_USERNAME"],
+        password=os.environ["MYSQL_PASSWORD"],
+        host=instance_address,
+        port=instance_port,
+    )
 
     executor.execute_sql("SET @@GLOBAL.enforce_gtid_consistency = 'ON'")
-    executor.execute_sql("SET @@GLOBAL.server_id = 1")
 
     gtid_mode = executor.execute_sql("SELECT @@GLOBAL.gtid_mode AS gtid_mode")
     gtid_mode = gtid_mode[0]["gtid_mode"]
@@ -41,5 +52,34 @@ def initialize_cluster():
     for mode in _GTID_MODES_ORDERED[gtid_mode_index:]:
         executor.execute_sql(f"SET @@GLOBAL.gtid_mode = '{mode}'")
 
-    with suppress(Exception):
-        executor.execute_py(f"dba.create_cluster('{TEST_CLUSTER_NAME}')")
+
+def _join_instance(instance_address: str, instance_port: str) -> None:
+    """Joins an instance to the testing InnoDB cluster."""
+    executor = build_local_executor(
+        username=os.environ["MYSQL_USERNAME"],
+        password=os.environ["MYSQL_PASSWORD"],
+        host=TEST_CLUSTER_HOST,
+        port=TEST_CLUSTER_PORT,
+    )
+
+    executor.execute_py(
+        "\n".join((
+            f"cluster = dba.get_cluster('{TEST_CLUSTER_NAME}')",
+            f"cluster.add_instance("
+            f"  instance='{instance_address}:{instance_port}',"
+            f"  options={{'recoveryMethod': 'incremental'}},"
+            f")",
+        )),
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def initialize_cluster():
+    """Initializes InnoDB cluster in an idempotent way."""
+    _config_instance(instance_address=TEST_CLUSTER_HOST, instance_port="3306")
+    _config_instance(instance_address=TEST_CLUSTER_HOST, instance_port="3307")
+    _config_instance(instance_address=TEST_CLUSTER_HOST, instance_port="3308")
+
+    _create_cluster()
+    _join_instance(instance_address=TEST_CLUSTER_HOST, instance_port="3307")
+    _join_instance(instance_address=TEST_CLUSTER_HOST, instance_port="3308")

--- a/tests/clients/test_instance.py
+++ b/tests/clients/test_instance.py
@@ -239,7 +239,7 @@ class TestInstanceClient:
     def test_get_cluster_instance_labels(self, client: MySQLInstanceClient):
         """Test the fetching of all the cluster instance labels."""
         labels = client.get_cluster_instance_labels(TEST_CLUSTER_NAME)
-        assert len(labels) == 1
+        assert len(labels) == 3
 
     def test_get_cluster_labels(self, client: MySQLInstanceClient):
         """Test the fetching of all the cluster labels."""
@@ -304,16 +304,16 @@ class TestInstanceClient:
     def test_search_instance_replication_members(self, client: MySQLInstanceClient):
         """Test the searching of instance replication members."""
         members = client.search_instance_replication_members()
-        assert len(members) == 1
+        assert len(members) == 3
 
         primary_members = client.search_instance_replication_members([InstanceRole.PRIMARY], [])
         replica_members = client.search_instance_replication_members([InstanceRole.SECONDARY], [])
         assert len(primary_members) == 1
-        assert len(replica_members) == 0
+        assert len(replica_members) == 2
 
         online_members = client.search_instance_replication_members([], [InstanceState.ONLINE])
         offline_members = client.search_instance_replication_members([], [InstanceState.OFFLINE])
-        assert len(online_members) == 1
+        assert len(online_members) == 3
         assert len(offline_members) == 0
 
         with pytest.raises(ValueError):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,6 +11,8 @@ from mysql_shell.executors import LocalExecutor
 from mysql_shell.models import ConnectionDetails, VariableScope
 
 TEST_CLUSTER_NAME = "test-cluster"
+TEST_CLUSTER_HOST = "0.0.0.0"
+TEST_CLUSTER_PORT = "3306"
 
 
 def build_local_executor(username: str, password: str, host: str = "0.0.0.0", port: str = "3306"):


### PR DESCRIPTION
This PR defines the necessary Docker compose services and `conftest.py` logic so that a full 3 unit cluster is spawned before running any of the cluster / instance client integration tests. This is a significant improvement with respect to the previous setup, as it brings the test suite closer to a production environment.

### Clarification:
Given the limitation when restarting the MySQL Server (neither Docker nor Podman handle it correctly), the instances configuration options are split between before and after start-up:
- Before startup:
  - [8.*] `server-id`.
  - [8.0] `binlog-transaction-dependency-tracking`.
- After startup:
  - [8.*] `enforce-gtid-consistency`.
  - [8.*] `gtid-mode`