### PR TITLE
[MISC] Reduce cluster labels noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 
 ## Unreleased
+### Fixed
+- Reduce logging level when failing to get cluster labels.
 
 ## [0.9.0][changes-0.9.0] - 2026-04-13
 ### Added

--- a/src/mysql_shell/clients/instance.py
+++ b/src/mysql_shell/clients/instance.py
@@ -224,8 +224,8 @@ class MySQLInstanceClient:
 
         try:
             rows = self._executor.execute_sql(query)
-        except ExecutionError:
-            logger.error("Failed to get cluster labels")
+        except ExecutionError as exc:
+            logger.debug("Failed to get cluster labels: %s", exc)
             raise
         else:
             return [row["cluster_name"] for row in rows]

--- a/src/mysql_shell/clients/instance.py
+++ b/src/mysql_shell/clients/instance.py
@@ -225,7 +225,7 @@ class MySQLInstanceClient:
         try:
             rows = self._executor.execute_sql(query)
         except ExecutionError as exc:
-            logger.debug("Failed to get cluster labels: %s", exc)
+            logger.debug(f"Failed to get cluster labels: {exc}")
             raise
         else:
             return [row["cluster_name"] for row in rows]


### PR DESCRIPTION
This is a proposal to reduce "Failed to get cluster labels" logs noise, which sometimes confuses users ([ref](https://matrix.to/#/!UdMFp6PW7upvLcqtiq_KQggh80xzNywIde5lxVr2BxY/$T6BZOJwMyPoJ0LPxg9zsAeQwT-1YDB-q0pTiIwiVxs0?via=ubuntu.com&via=matrix.org&via=laquadrature.net)). Now it requires DEBUG level enabled _and_ it will show an actual reason (but not the full traceback). Since the exception is re-raised anyway, further handling can be done up in the stack.