### PR TITLE
[MISC] Expose Execute classes timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 
 ## Unreleased
+### Added
+- Timeout argument to BaseExecutor classes.
+
 ### Fixed
+- Rename quoter and client classes.
 - Reduce logging level when failing to get cluster labels.
 
 ## [0.9.0][changes-0.9.0] - 2026-04-13

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ in addition to a set of predefined queries to cover most of the common use-cases
 
 5. Import and build the clients:
    ```python
-   from mysql_shell.builders.quoting import StringQueryQuoter
+   from mysql_shell.builders.quoting import QueryQuoter
    from mysql_shell.clients import ClusterClient, InstanceClient
 
-   quoter = StringQueryQuoter()
+   quoter = QueryQuoter()
 
    cluster_client = ClusterClient(cluster_executor, quoter)
    instance_client = InstanceClient(instance_executor, quoter)

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ in addition to a set of predefined queries to cover most of the common use-cases
 5. Import and build the clients:
    ```python
    from mysql_shell.builders.quoting import StringQueryQuoter
-   from mysql_shell.clients import MySQLClusterClient, MySQLInstanceClient
+   from mysql_shell.clients import ClusterClient, InstanceClient
 
    quoter = StringQueryQuoter()
 
-   cluster_client = MySQLClusterClient(cluster_executor, quoter)
-   instance_client = MySQLInstanceClient(instance_executor, quoter)
+   cluster_client = ClusterClient(cluster_executor, quoter)
+   instance_client = InstanceClient(instance_executor, quoter)
    ```
 
 ## 🔧 Development

--- a/src/mysql_shell/builders/authorization/charm.py
+++ b/src/mysql_shell/builders/authorization/charm.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from ..quoting import StringQueryQuoter
+from ..quoting import QueryQuoter
 from .base import BaseAuthorizationQueryBuilder
 
 
@@ -43,7 +43,7 @@ class CharmAuthorizationQueryBuilder(BaseAuthorizationQueryBuilder):
         role_writer: str,
     ):
         """Initialize the query builder."""
-        self._quoter = StringQueryQuoter()
+        self._quoter = QueryQuoter()
         self._role_admin = self._quoter.quote_identifier(role_admin)
         self._role_backup = self._quoter.quote_identifier(role_backup)
         self._role_ddl = self._quoter.quote_identifier(role_ddl)

--- a/src/mysql_shell/builders/locking/charm.py
+++ b/src/mysql_shell/builders/locking/charm.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from ..quoting import StringQueryQuoter
+from ..quoting import QueryQuoter
 from .base import BaseLockingQueryBuilder
 
 
@@ -18,7 +18,7 @@ class CharmLockingQueryBuilder(BaseLockingQueryBuilder):
 
     def __init__(self, table_schema: str, table_name: str):
         """Initialize the query builder."""
-        self._quoter = StringQueryQuoter()
+        self._quoter = QueryQuoter()
         self._table = "{table_schema}.{table_name}".format(
             table_schema=self._quoter.quote_identifier(table_schema),
             table_name=self._quoter.quote_identifier(table_name),

--- a/src/mysql_shell/builders/logging/charm.py
+++ b/src/mysql_shell/builders/logging/charm.py
@@ -4,7 +4,7 @@
 from typing import Sequence
 
 from ...models import LogType
-from ..quoting import StringQueryQuoter
+from ..quoting import QueryQuoter
 from .base import BaseLoggingQueryBuilder
 
 
@@ -13,7 +13,7 @@ class CharmLoggingQueryBuilder(BaseLoggingQueryBuilder):
 
     def __init__(self):
         """Initialize the query builder."""
-        self._quoter = StringQueryQuoter()
+        self._quoter = QueryQuoter()
 
     def build_logs_flushing_query(self, logs: Sequence[LogType] | None = None) -> str:
         """Builds the logs flushing query.

--- a/src/mysql_shell/builders/quoting.py
+++ b/src/mysql_shell/builders/quoting.py
@@ -5,7 +5,7 @@ from functools import cache
 from typing import Any
 
 
-class StringQueryQuoter:
+class QueryQuoter:
     """Class to escape and quote MySQL query input parameters."""
 
     @staticmethod

--- a/src/mysql_shell/clients/cluster.py
+++ b/src/mysql_shell/clients/cluster.py
@@ -13,7 +13,7 @@ logger = logging.getLogger()
 _Options = Mapping[str, str] | None
 
 
-class MySQLClusterClient:
+class ClusterClient:
     """Class to encapsulate all cluster operations using MySQL Shell."""
 
     def __init__(self, executor: BaseExecutor):

--- a/src/mysql_shell/clients/cluster.py
+++ b/src/mysql_shell/clients/cluster.py
@@ -22,6 +22,9 @@ class ClusterClient:
 
     def create_cluster(self, cluster_name: str, options: _Options = None) -> None:
         """Creates an InnoDB cluster."""
+        if not options:
+            options = {}
+
         command = f"dba.create_cluster('{cluster_name}', {options})"
 
         try:
@@ -33,6 +36,9 @@ class ClusterClient:
 
     def destroy_cluster(self, cluster_name: str, options: _Options = None) -> None:
         """Destroys an InnoDB cluster."""
+        if not options:
+            options = {}
+
         command = "\n".join((
             f"cluster = dba.get_cluster('{cluster_name}')",
             f"cluster.dissolve({options})",
@@ -54,7 +60,7 @@ class ClusterClient:
         ))
 
         try:
-            result = self._executor.execute_py(command, timeout=30)
+            result = self._executor.execute_py(command)
         except ExecutionError:
             logger.error("Failed to fetch cluster status")
             raise
@@ -79,6 +85,9 @@ class ClusterClient:
 
     def rescan_cluster(self, cluster_name: str, options: _Options = None) -> None:
         """Rescans an InnoDB cluster."""
+        if not options:
+            options = {}
+
         command = "\n".join((
             f"cluster = dba.get_cluster('{cluster_name}')",
             f"cluster.rescan({options})",
@@ -93,6 +102,9 @@ class ClusterClient:
 
     def reboot_cluster(self, cluster_name: str, options: _Options = None) -> None:
         """Reboots an InnoDB cluster."""
+        if not options:
+            options = {}
+
         command = f"dba.reboot_cluster_from_complete_outage('{cluster_name}', {options})"
 
         try:
@@ -127,7 +139,7 @@ class ClusterClient:
         ))
 
         try:
-            result = self._executor.execute_py(command, timeout=120)
+            result = self._executor.execute_py(command)
         except ExecutionError:
             logger.error("Failed to fetch cluster set status")
             raise
@@ -159,6 +171,9 @@ class ClusterClient:
         options: _Options = None,
     ) -> None:
         """Creates an InnoDB replica cluster into the cluster set."""
+        if not options:
+            options = {}
+
         address = f"{source_host}:{source_port}"
         command = f"\n".join((
             f"shell.connect_to_primary()",
@@ -196,6 +211,9 @@ class ClusterClient:
 
     def remove_cluster_set_replica(self, cluster_name: str, options: _Options = None) -> None:
         """Removes an InnoDB replica cluster from the cluster set."""
+        if not options:
+            options = {}
+
         command = "\n".join((
             f"shell.connect_to_primary()",
             f"cluster_set = dba.get_cluster_set()",
@@ -232,6 +250,9 @@ class ClusterClient:
         options: _Options = None,
     ) -> None:
         """Attached an instance into an InnoDB cluster."""
+        if not options:
+            options = {}
+
         address = f"{instance_host}:{instance_port}"
         command = f"\n".join((
             f"cluster = dba.get_cluster('{cluster_name}')",
@@ -253,6 +274,9 @@ class ClusterClient:
         options: _Options = None,
     ) -> None:
         """Detaches an instance from an InnoDB cluster."""
+        if not options:
+            options = {}
+
         address = f"{instance_host}:{instance_port}"
         command = f"\n".join((
             f"cluster = dba.get_cluster('{cluster_name}')",
@@ -294,6 +318,9 @@ class ClusterClient:
         options: _Options = None,
     ) -> None:
         """Rejoins an instance back into its InnoDB cluster."""
+        if not options:
+            options = {}
+
         address = f"{instance_host}:{instance_port}"
         command = f"\n".join((
             f"cluster = dba.get_cluster('{cluster_name}')",
@@ -309,6 +336,9 @@ class ClusterClient:
 
     def check_instance_before_cluster(self, options: _Options = None) -> dict:
         """Checks for an instance configuration before joining an InnoDB cluster."""
+        if not options:
+            options = {}
+
         command = "\n".join((
             f"result = dba.check_instance_configuration(options={options})",
             f"print(result)",
@@ -328,6 +358,9 @@ class ClusterClient:
 
     def setup_instance_before_cluster(self, options: _Options = None) -> None:
         """Sets up an instance configuration before joining an InnoDB cluster."""
+        if not options:
+            options = {}
+
         command = f"dba.configure_instance(options={options})"
         host = self._executor.connection_details.host
         port = self._executor.connection_details.port
@@ -375,10 +408,11 @@ class ClusterClient:
         options: _Options = None,
     ) -> None:
         """Updates an instance within an InnoDB cluster."""
+        if not options:
+            options = {}
+
         address = f"{instance_host}:{instance_port}"
-        command = [
-            f"cluster = dba.get_cluster('{cluster_name}')",
-        ]
+        command = [f"cluster = dba.get_cluster('{cluster_name}')"]
 
         for key, val in options.items():
             val = f"'{val}'" if isinstance(val, str) else val

--- a/src/mysql_shell/clients/instance.py
+++ b/src/mysql_shell/clients/instance.py
@@ -5,7 +5,7 @@ import json
 import logging
 from typing import Any, Mapping, Sequence
 
-from ..builders import StringQueryQuoter
+from ..builders import QueryQuoter
 from ..executors import BaseExecutor
 from ..executors.errors import ExecutionError
 from ..models.account import Role, User
@@ -20,7 +20,7 @@ _Attrs = Mapping[str, str] | None
 class InstanceClient:
     """Class to encapsulate all instance operations using MySQL Shell."""
 
-    def __init__(self, executor: BaseExecutor, quoter: StringQueryQuoter):
+    def __init__(self, executor: BaseExecutor, quoter: QueryQuoter):
         """Initialize the class."""
         self._executor = executor
         self._quoter = quoter

--- a/src/mysql_shell/clients/instance.py
+++ b/src/mysql_shell/clients/instance.py
@@ -17,7 +17,7 @@ logger = logging.getLogger()
 _Attrs = Mapping[str, str] | None
 
 
-class MySQLInstanceClient:
+class InstanceClient:
     """Class to encapsulate all instance operations using MySQL Shell."""
 
     def __init__(self, executor: BaseExecutor, quoter: StringQueryQuoter):

--- a/src/mysql_shell/executors/base.py
+++ b/src/mysql_shell/executors/base.py
@@ -10,10 +10,11 @@ from ..models import ConnectionDetails
 class BaseExecutor(ABC):
     """Base class for all MySQL Shell executors."""
 
-    def __init__(self, conn_details: ConnectionDetails, shell_path: str):
+    def __init__(self, conn_details: ConnectionDetails, shell_path: str, timeout: int):
         """Initialize the executor."""
         self._conn_details = conn_details
         self._shell_path = shell_path
+        self._timeout = timeout
 
     @property
     def connection_details(self) -> ConnectionDetails:

--- a/src/mysql_shell/executors/local.py
+++ b/src/mysql_shell/executors/local.py
@@ -86,19 +86,19 @@ class LocalExecutor(BaseExecutor):
                 yield val
 
     @staticmethod
-    def _strip_password(error: subprocess.SubprocessError):
+    def _strip_password(exc: subprocess.SubprocessError):
         """Strip passwords from SQL scripts."""
-        if not hasattr(error, "cmd"):
-            return error
+        if not isinstance(exc, subprocess.CalledProcessError):
+            return exc
 
         password_pattern = re.compile("(?<=IDENTIFIED BY ')[^']+(?=')")
         password_replace = "*****"
 
-        for index, value in enumerate(error.cmd):
+        for index, value in enumerate(exc.cmd):
             if "IDENTIFIED BY" in value:
-                error.cmd[index] = re.sub(password_pattern, password_replace, value)
+                exc.cmd[index] = re.sub(password_pattern, password_replace, value)
 
-        return error
+        return exc
 
     def check_connection(self) -> None:
         """Check the connection."""

--- a/src/mysql_shell/executors/local.py
+++ b/src/mysql_shell/executors/local.py
@@ -14,9 +14,9 @@ from .errors import ExecutionError
 class LocalExecutor(BaseExecutor):
     """Local executor for the MySQL Shell."""
 
-    def __init__(self, conn_details: ConnectionDetails, shell_path: str):
+    def __init__(self, conn_details: ConnectionDetails, shell_path: str, timeout: int = 60):
         """Initialize the executor."""
-        super().__init__(conn_details, shell_path)
+        super().__init__(conn_details, shell_path, timeout)
 
     def _common_args(self) -> list[str]:
         """Return the list of common arguments."""
@@ -147,7 +147,7 @@ class LocalExecutor(BaseExecutor):
         try:
             process = subprocess.run(
                 command,
-                timeout=timeout,
+                timeout=timeout or self._timeout,
                 input=self._conn_details.password,
                 capture_output=True,
                 check=True,
@@ -182,7 +182,7 @@ class LocalExecutor(BaseExecutor):
         try:
             process = subprocess.run(
                 command,
-                timeout=timeout,
+                timeout=timeout or self._timeout,
                 input=self._conn_details.password,
                 capture_output=True,
                 check=True,

--- a/tests/builders/test_quoting.py
+++ b/tests/builders/test_quoting.py
@@ -3,23 +3,23 @@
 
 import pytest
 
-from mysql_shell.builders import StringQueryQuoter
+from mysql_shell.builders import QueryQuoter
 
 
 @pytest.mark.unit
-class TestStringQueryQuoter:
-    """Class to group all the StringQueryQuoter tests."""
+class TestQueryQuoter:
+    """Class to group all the QueryQuoter tests."""
 
     def test_quote_value(self):
         """Test the quote_value method."""
-        quoter = StringQueryQuoter()
+        quoter = QueryQuoter()
 
         assert quoter.quote_value("test") == "'test'"
         assert quoter.quote_value("'; injected code ;'") == "'\\'; injected code ;\\''"
 
     def test_quote_identifier(self):
         """Test the quote_identifier method."""
-        quoter = StringQueryQuoter()
+        quoter = QueryQuoter()
 
         assert quoter.quote_identifier("test") == "`test`"
         assert quoter.quote_value("`; injected code ;`") == "'\\`; injected code ;\\`'"

--- a/tests/clients/test_cluster.py
+++ b/tests/clients/test_cluster.py
@@ -5,7 +5,7 @@ import os
 
 import pytest
 
-from mysql_shell.clients import MySQLClusterClient
+from mysql_shell.clients import ClusterClient
 from mysql_shell.executors import LocalExecutor
 
 from ..helpers import (
@@ -16,7 +16,7 @@ from ..helpers import (
 
 @pytest.mark.integration
 class TestClusterClient:
-    """Class to group all the MySQLClusterClient tests."""
+    """Class to group all the ClusterClient tests."""
 
     @pytest.fixture(scope="class", autouse=True)
     def executor(self):
@@ -29,10 +29,10 @@ class TestClusterClient:
     @pytest.fixture(scope="class", autouse=True)
     def client(self, executor: LocalExecutor):
         """MySQL Cluster client fixture."""
-        return MySQLClusterClient(executor)
+        return ClusterClient(executor)
 
     @staticmethod
-    def _get_member_address(client: MySQLClusterClient) -> str:
+    def _get_member_address(client: ClusterClient) -> str:
         """Get the member address."""
         query = (
             "SELECT CONCAT(member_host, ':', member_port) AS address "
@@ -44,24 +44,24 @@ class TestClusterClient:
         host = rows[0]["address"]
         return host
 
-    def test_fetch_cluster_status(self, client: MySQLClusterClient):
+    def test_fetch_cluster_status(self, client: ClusterClient):
         """Test the fetching of the cluster status."""
         status = client.fetch_cluster_status(TEST_CLUSTER_NAME)
         assert status.get("defaultReplicaSet", {})
         assert status.get("defaultReplicaSet", {}).get("topology")
 
-    def test_list_cluster_routers(self, client: MySQLClusterClient):
+    def test_list_cluster_routers(self, client: ClusterClient):
         """Test the listing of the cluster routers."""
         routers = client.list_cluster_routers(TEST_CLUSTER_NAME)
         routers = routers["routers"]
         assert len(routers) == 0
 
-    def test_check_instance_before_cluster(self, client: MySQLClusterClient):
+    def test_check_instance_before_cluster(self, client: ClusterClient):
         """Test the checking of an instance config before joining a cluster."""
         result = client.check_instance_before_cluster()
         assert result["status"] == "ok"
 
-    def test_update_instance_within_cluster(self, client: MySQLClusterClient):
+    def test_update_instance_within_cluster(self, client: ClusterClient):
         """Test the updating an instance config within a cluster."""
         address = self._get_member_address(client)
 

--- a/tests/clients/test_cluster.py
+++ b/tests/clients/test_cluster.py
@@ -9,6 +9,7 @@ from mysql_shell.clients import ClusterClient
 from mysql_shell.executors import LocalExecutor
 
 from ..helpers import (
+    TEST_CLUSTER_HOST,
     TEST_CLUSTER_NAME,
     build_local_executor,
 )
@@ -60,6 +61,24 @@ class TestClusterClient:
         """Test the checking of an instance config before joining a cluster."""
         result = client.check_instance_before_cluster()
         assert result["status"] == "ok"
+
+    def test_promote_instance_within_cluster(self, client: ClusterClient):
+        """Test the promotion of an instance within a cluster."""
+        status = client.fetch_cluster_status(TEST_CLUSTER_NAME)
+        primary = status.get("defaultReplicaSet", {}).get("primary", "")
+        assert primary.endswith("3306")
+
+        client.promote_instance_within_cluster(TEST_CLUSTER_NAME, TEST_CLUSTER_HOST, "3307")
+
+        status = client.fetch_cluster_status(TEST_CLUSTER_NAME)
+        primary = status.get("defaultReplicaSet", {}).get("primary", "")
+        assert primary.endswith("3307")
+
+        client.promote_instance_within_cluster(TEST_CLUSTER_NAME, TEST_CLUSTER_HOST, "3306")
+
+        status = client.fetch_cluster_status(TEST_CLUSTER_NAME)
+        primary = status.get("defaultReplicaSet", {}).get("primary", "")
+        assert primary.endswith("3306")
 
     def test_update_instance_within_cluster(self, client: ClusterClient):
         """Test the updating an instance config within a cluster."""

--- a/tests/clients/test_instance.py
+++ b/tests/clients/test_instance.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 from mysql_shell.builders import StringQueryQuoter
-from mysql_shell.clients import MySQLInstanceClient
+from mysql_shell.clients import InstanceClient
 from mysql_shell.executors import LocalExecutor
 from mysql_shell.models.account import Role, User
 from mysql_shell.models.instance import InstanceRole, InstanceState
@@ -21,7 +21,7 @@ from ..helpers import (
 
 @pytest.mark.integration
 class TestInstanceClient:
-    """Class to group all the MySQLInstanceClient tests."""
+    """Class to group all the InstanceClient tests."""
 
     @pytest.fixture(scope="class", autouse=True)
     def executor(self):
@@ -34,10 +34,10 @@ class TestInstanceClient:
     @pytest.fixture(scope="class", autouse=True)
     def client(self, executor: LocalExecutor):
         """MySQL Instance client fixture."""
-        return MySQLInstanceClient(executor, StringQueryQuoter())
+        return InstanceClient(executor, StringQueryQuoter())
 
     @staticmethod
-    def _delete_database(client: MySQLInstanceClient, database: str):
+    def _delete_database(client: InstanceClient, database: str):
         """Get the granted roles for a user."""
         query = "DROP DATABASE IF EXISTS `{database}`"
         query = query.format(
@@ -47,7 +47,7 @@ class TestInstanceClient:
         client._executor.execute_sql(query)
 
     @staticmethod
-    def _delete_user(client: MySQLInstanceClient, user: User):
+    def _delete_user(client: InstanceClient, user: User):
         """Get the granted roles for a user."""
         query = "DROP USER IF EXISTS `{username}`@`{hostname}`"
         query = query.format(
@@ -58,7 +58,7 @@ class TestInstanceClient:
         client._executor.execute_sql(query)
 
     @staticmethod
-    def _delete_role(client: MySQLInstanceClient, role: Role):
+    def _delete_role(client: InstanceClient, role: Role):
         """Get the granted roles for a user."""
         query = "DROP ROLE IF EXISTS `{rolename}`@`{hostname}`"
         query = query.format(
@@ -69,7 +69,7 @@ class TestInstanceClient:
         client._executor.execute_sql(query)
 
     @staticmethod
-    def _get_granted_roles(client: MySQLInstanceClient, entity: User | Role):
+    def _get_granted_roles(client: InstanceClient, entity: User | Role):
         """Get the granted roles for a user."""
         query = (
             "SELECT from_user "
@@ -86,7 +86,7 @@ class TestInstanceClient:
         return users
 
     @staticmethod
-    def _get_processes(client: MySQLInstanceClient, info: str):
+    def _get_processes(client: InstanceClient, info: str):
         """Get the processes by statement."""
         query = (
             "SELECT processlist_id "
@@ -99,11 +99,11 @@ class TestInstanceClient:
         procs = [row["processlist_id"] for row in rows]
         return procs
 
-    def test_check_work_ongoing(self, client: MySQLInstanceClient):
+    def test_check_work_ongoing(self, client: InstanceClient):
         """Test the checking of instance work."""
         assert not client.check_work_ongoing("%")
 
-    def test_create_instance_database(self, client: MySQLInstanceClient):
+    def test_create_instance_database(self, client: InstanceClient):
         """Test the creation of an instance database."""
         database = "instance_database_create"
 
@@ -114,7 +114,7 @@ class TestInstanceClient:
         finally:
             self._delete_database(client, database)
 
-    def test_create_instance_role_without_roles(self, client: MySQLInstanceClient):
+    def test_create_instance_role_without_roles(self, client: InstanceClient):
         """Test the creation of an instance role."""
         role = Role("instance_role_create", "%")
 
@@ -125,7 +125,7 @@ class TestInstanceClient:
         finally:
             self._delete_role(client, role)
 
-    def test_create_instance_role_with_roles(self, client: MySQLInstanceClient):
+    def test_create_instance_role_with_roles(self, client: InstanceClient):
         """Test the creation of an instance role."""
         role = Role("instance_role_create", "%")
 
@@ -141,7 +141,7 @@ class TestInstanceClient:
         finally:
             self._delete_role(client, role)
 
-    def test_create_instance_user_without_roles(self, client: MySQLInstanceClient):
+    def test_create_instance_user_without_roles(self, client: InstanceClient):
         """Test the creation of an instance user."""
         user = User("instance_user_create", "%")
 
@@ -152,7 +152,7 @@ class TestInstanceClient:
         finally:
             self._delete_user(client, user)
 
-    def test_create_instance_user_with_roles(self, client: MySQLInstanceClient):
+    def test_create_instance_user_with_roles(self, client: InstanceClient):
         """Test the creation of an instance user."""
         user = User("instance_user_create", "%")
 
@@ -168,7 +168,7 @@ class TestInstanceClient:
         finally:
             self._delete_user(client, user)
 
-    def test_delete_instance_user(self, client: MySQLInstanceClient):
+    def test_delete_instance_user(self, client: InstanceClient):
         """Test the deletion of an instance user."""
         user = User("instance_user_delete", "%")
 
@@ -181,7 +181,7 @@ class TestInstanceClient:
         finally:
             self._delete_user(client, user)
 
-    def test_delete_instance_users(self, client: MySQLInstanceClient):
+    def test_delete_instance_users(self, client: InstanceClient):
         """Test the deletion of a range of instance users."""
         user_1 = User("instance_user_delete_1", "%")
         user_2 = User("instance_user_delete_2", "%")
@@ -201,7 +201,7 @@ class TestInstanceClient:
             self._delete_user(client, user_1)
             self._delete_user(client, user_2)
 
-    def test_update_instance_user_password(self, client: MySQLInstanceClient):
+    def test_update_instance_user_password(self, client: InstanceClient):
         """Test the updating of an instance user password."""
         instance_user = User("instance_user_update", "%")
 
@@ -214,7 +214,7 @@ class TestInstanceClient:
         finally:
             self._delete_user(client, instance_user)
 
-    def test_update_instance_user_attributes(self, client: MySQLInstanceClient):
+    def test_update_instance_user_attributes(self, client: InstanceClient):
         """Test the updating of an instance user attributes."""
         old_attrs = {"key": "val_1"}
         new_attrs = {"key": "val_2"}
@@ -231,33 +231,33 @@ class TestInstanceClient:
         finally:
             self._delete_user(client, instance_user)
 
-    def test_get_cluster_instance_label(self, client: MySQLInstanceClient):
+    def test_get_cluster_instance_label(self, client: InstanceClient):
         """Test the fetching of the cluster instance label."""
         label = client.get_cluster_instance_label()
         assert label.endswith(":3306")
 
-    def test_get_cluster_instance_labels(self, client: MySQLInstanceClient):
+    def test_get_cluster_instance_labels(self, client: InstanceClient):
         """Test the fetching of all the cluster instance labels."""
         labels = client.get_cluster_instance_labels(TEST_CLUSTER_NAME)
         assert len(labels) == 3
 
-    def test_get_cluster_labels(self, client: MySQLInstanceClient):
+    def test_get_cluster_labels(self, client: InstanceClient):
         """Test the fetching of all the cluster labels."""
         assert TEST_CLUSTER_NAME in client.get_cluster_labels()
 
-    def test_get_instance_replication_state(self, client: MySQLInstanceClient):
+    def test_get_instance_replication_state(self, client: InstanceClient):
         """Test the fetching of the instance replication state."""
         assert client.get_instance_replication_state() == InstanceState.ONLINE
 
-    def test_get_instance_replication_role(self, client: MySQLInstanceClient):
+    def test_get_instance_replication_role(self, client: InstanceClient):
         """Test the fetching of the instance replication role."""
         assert client.get_instance_replication_role() == InstanceRole.PRIMARY
 
-    def test_get_instance_variable(self, client: MySQLInstanceClient):
+    def test_get_instance_variable(self, client: InstanceClient):
         """Test the fetching of an instance variable."""
         assert client.get_instance_variable(VariableScope.GLOBAL, "super_read_only") == 0
 
-    def test_set_instance_variable(self, client: MySQLInstanceClient):
+    def test_set_instance_variable(self, client: InstanceClient):
         """Test the fetching of an instance variable."""
         var_name = "max_connections"
         var_value = 100
@@ -271,7 +271,7 @@ class TestInstanceClient:
         client.set_instance_variable(VariableScope.GLOBAL, var_name, var_value)
         assert client.get_instance_variable(VariableScope.GLOBAL, var_name) == var_value
 
-    def test_install_plugin(self, client: MySQLInstanceClient):
+    def test_install_plugin(self, client: InstanceClient):
         """Test the installation of an instance plugin."""
         plugins = client.search_instance_plugins("%")
         assert "auth_socket" not in plugins
@@ -284,7 +284,7 @@ class TestInstanceClient:
         finally:
             client.uninstall_instance_plugin("auth_socket")
 
-    def test_install_component(self, client: MySQLInstanceClient):
+    def test_install_component(self, client: InstanceClient):
         """Test the installation of a component."""
         components = client.search_instance_components("%")
         assert "file://component_validate_password" not in components
@@ -297,11 +297,11 @@ class TestInstanceClient:
         finally:
             client.uninstall_instance_component("file://component_validate_password")
 
-    def test_reload_instance_certs(self, client: MySQLInstanceClient):
+    def test_reload_instance_certs(self, client: InstanceClient):
         """Test the reloading of instance TLS certificates."""
         pass
 
-    def test_search_instance_replication_members(self, client: MySQLInstanceClient):
+    def test_search_instance_replication_members(self, client: InstanceClient):
         """Test the searching of instance replication members."""
         members = client.search_instance_replication_members()
         assert len(members) == 3
@@ -322,7 +322,7 @@ class TestInstanceClient:
                 states=[InstanceState.ONLINE],
             )
 
-    def test_search_instance_connections(self, client: MySQLInstanceClient):
+    def test_search_instance_connections(self, client: InstanceClient):
         """Test the searching of instance connections given a name-pattern."""
         query = "DO SLEEP(10)"
 
@@ -333,7 +333,7 @@ class TestInstanceClient:
             assert process_ids[0] in client.search_instance_connection_processes("%")
             assert process_ids[0] not in client.search_instance_connection_processes("search")
 
-    def test_search_instance_databases(self, client: MySQLInstanceClient):
+    def test_search_instance_databases(self, client: InstanceClient):
         """Test the searching of instance databases given a name-pattern."""
         dbs = client.search_instance_databases("%")
         assert "mysql" in dbs
@@ -343,18 +343,18 @@ class TestInstanceClient:
         dbs = client.search_instance_databases("database_search")
         assert not dbs
 
-    def test_search_instance_plugins(self, client: MySQLInstanceClient):
+    def test_search_instance_plugins(self, client: InstanceClient):
         """Test the searching of instance plugins given a name-pattern."""
         plugins = client.search_instance_plugins("%")
         assert "clone" in plugins
         assert "group_replication" in plugins
 
-    def test_search_instance_components(self, client: MySQLInstanceClient):
+    def test_search_instance_components(self, client: InstanceClient):
         """Test the searching of instance components given a URN pattern."""
         components = client.search_instance_components("%")
         assert not components
 
-    def test_search_instance_roles(self, client: MySQLInstanceClient):
+    def test_search_instance_roles(self, client: InstanceClient):
         """Test the searching of instance roles given a name-pattern."""
         role = Role("instance_role_search", "%")
 
@@ -366,7 +366,7 @@ class TestInstanceClient:
         finally:
             self._delete_role(client, role)
 
-    def test_search_instance_users_without_attrs(self, client: MySQLInstanceClient):
+    def test_search_instance_users_without_attrs(self, client: InstanceClient):
         """Test the searching of instance users given a name-pattern."""
         user = User("instance_user_search", "%", {})
 
@@ -378,7 +378,7 @@ class TestInstanceClient:
         finally:
             self._delete_user(client, user)
 
-    def test_search_instance_users_with_attrs(self, client: MySQLInstanceClient):
+    def test_search_instance_users_with_attrs(self, client: InstanceClient):
         """Test the searching of instance users given a name-pattern and attributes."""
         user = User("instance_user_search", "%", {"key": "val"})
 
@@ -390,15 +390,15 @@ class TestInstanceClient:
         finally:
             self._delete_user(client, user)
 
-    def test_start_instance_replication(self, client: MySQLInstanceClient):
+    def test_start_instance_replication(self, client: InstanceClient):
         """Test the starting of group replication."""
         pass
 
-    def test_stop_instance_replication(self, client: MySQLInstanceClient):
+    def test_stop_instance_replication(self, client: InstanceClient):
         """Test the stopping of group replication."""
         pass
 
-    def test_stop_instance_processes(self, client: MySQLInstanceClient):
+    def test_stop_instance_processes(self, client: InstanceClient):
         """Test the stopping of processes."""
         client.stop_instance_processes([])
 

--- a/tests/clients/test_instance.py
+++ b/tests/clients/test_instance.py
@@ -5,7 +5,7 @@ import os
 
 import pytest
 
-from mysql_shell.builders import StringQueryQuoter
+from mysql_shell.builders import QueryQuoter
 from mysql_shell.clients import InstanceClient
 from mysql_shell.executors import LocalExecutor
 from mysql_shell.models.account import Role, User
@@ -34,7 +34,7 @@ class TestInstanceClient:
     @pytest.fixture(scope="class", autouse=True)
     def client(self, executor: LocalExecutor):
         """MySQL Instance client fixture."""
-        return InstanceClient(executor, StringQueryQuoter())
+        return InstanceClient(executor, QueryQuoter())
 
     @staticmethod
     def _delete_database(client: InstanceClient, database: str):


### PR DESCRIPTION
This PR exposes a `BaseExecutor` object level parameter to inject a timeout into every execution, unless an explicit timeout has been provided when calling the method themselves. This will simplify the setup when defining a timing out for cluster / instance clients.


### Additional changes:
- Renamed `MySQLClusterClient`, `MySQLInstanceClient` and `StringQueryQuoter` classes.
- Tweaked `MySQLClusterClient` to default to a safe options values whenever not provided.