### PR TITLE
[MISC] Define ClusterClient update-router method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 
 ## Unreleased
+### Added
+- Update router config to ClusterInstance class.
 
 ## [1.0.0][changes-1.0.0] - 2026-05-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 ## Unreleased
 ### Added
-- Update router config to ClusterInstance class.
+- Update router config to ClusterClient class.
 
 ## [1.0.0][changes-1.0.0] - 2026-05-26
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,13 +43,14 @@ in addition to a set of predefined queries to cover most of the common use-cases
 
 4. Import and build the clients:
    ```python
-   from mysql_shell.builders.quoting import QueryQuoter
+   from mysql_shell.builders.quoting import ArgsQuoter, QueryQuoter
    from mysql_shell.clients import ClusterClient, InstanceClient
 
-   quoter = QueryQuoter()
+   args_quoter = ArgsQuoter()
+   query_quoter = QueryQuoter()
 
-   cluster_client = ClusterClient(cluster_executor, quoter)
-   instance_client = InstanceClient(instance_executor, quoter)
+   cluster_client = ClusterClient(cluster_executor, args_quoter)
+   instance_client = InstanceClient(instance_executor, query_quoter)
    ```
 
 ## 🔧 Development

--- a/src/mysql_shell/builders/quoting.py
+++ b/src/mysql_shell/builders/quoting.py
@@ -6,10 +6,10 @@ from typing import Any
 
 
 class ArgsQuoter:
-    """Class to escape and quote MySQL Shell Python input parameters."""
+    """Class to quote MySQL Shell Python input parameters."""
 
-    @cache
-    def quote_value(self, value: Any) -> Any:
+    @staticmethod
+    def quote_value(value: Any) -> Any:
         """Quotes the provided value."""
         if isinstance(value, str):
             return f"'{value}'"

--- a/src/mysql_shell/builders/quoting.py
+++ b/src/mysql_shell/builders/quoting.py
@@ -5,8 +5,20 @@ from functools import cache
 from typing import Any
 
 
+class ArgsQuoter:
+    """Class to escape and quote MySQL Shell Python input parameters."""
+
+    @cache
+    def quote_value(self, value: Any) -> Any:
+        """Quotes the provided value."""
+        if isinstance(value, str):
+            return f"'{value}'"
+        else:
+            return value
+
+
 class QueryQuoter:
-    """Class to escape and quote MySQL query input parameters."""
+    """Class to escape and quote MySQL Shell SQL input parameters."""
 
     @staticmethod
     def escape(value: Any) -> Any:

--- a/src/mysql_shell/clients/cluster.py
+++ b/src/mysql_shell/clients/cluster.py
@@ -5,6 +5,7 @@ import json
 import logging
 from typing import Mapping
 
+from ..builders import ArgsQuoter
 from ..executors import BaseExecutor
 from ..executors.errors import ExecutionError
 
@@ -16,9 +17,10 @@ _Options = Mapping[str, str] | None
 class ClusterClient:
     """Class to encapsulate all cluster operations using MySQL Shell."""
 
-    def __init__(self, executor: BaseExecutor):
+    def __init__(self, executor: BaseExecutor, quoter: ArgsQuoter):
         """Initialize the class."""
         self._executor = executor
+        self._quoter = quoter
 
     def create_cluster(self, cluster_name: str, options: _Options = None) -> None:
         """Creates an InnoDB cluster."""
@@ -415,9 +417,9 @@ class ClusterClient:
         command = [f"cluster = dba.get_cluster('{cluster_name}')"]
 
         for key, val in options.items():
-            val = f"'{val}'" if isinstance(val, str) else val
-            cmd = f"cluster.set_instance_option('{address}', '{key}', {val})"
-            command.append(cmd)
+            quoted_key = self._quoter.quote_value(key)
+            quoted_val = self._quoter.quote_value(val)
+            command.append(f"cluster.set_instance_option('{address}', {quoted_key}, {quoted_val})")
 
         command = "\n".join(command)
 
@@ -435,14 +437,43 @@ class ClusterClient:
         router_mode: str,
     ) -> None:
         """Removes a router from an InnoDB cluster."""
+        router = f"{router_name}::{router_mode}"
         command = "\n".join((
             f"cluster = dba.get_cluster('{cluster_name}')",
-            f"cluster.remove_router_metadata('{router_name}::{router_mode}')",
+            f"cluster.remove_router_metadata('{router}')",
         ))
 
         try:
-            logger.debug(f"Removing router from cluster {cluster_name}")
+            logger.debug(f"Removing router {router} from cluster {cluster_name}")
             self._executor.execute_py(command)
         except ExecutionError:
-            logger.error(f"Failed to remove router from cluster {cluster_name}")
+            logger.error(f"Failed to remove router {router} from cluster {cluster_name}")
+            raise
+
+    def update_router_within_cluster(
+        self,
+        cluster_name: str,
+        router_name: str,
+        router_mode: str,
+        options: _Options = None,
+    ) -> None:
+        """Updates a router from an InnoDB cluster. This feature is MySQL 8.4+ exclusive."""
+        if not options:
+            options = {}
+
+        router = f"{router_name}::{router_mode}"
+        command = [f"cluster = dba.get_cluster('{cluster_name}')"]
+
+        for key, val in options.items():
+            quoted_key = self._quoter.quote_value(key)
+            quoted_val = self._quoter.quote_value(val)
+            command.append(f"cluster.set_routing_option('{router}', {quoted_key}, {quoted_val})")
+
+        command = "\n".join(command)
+
+        try:
+            logger.debug(f"Updating router {router} from cluster {cluster_name}")
+            self._executor.execute_py(command)
+        except ExecutionError:
+            logger.error(f"Failed to update router {router} from cluster {cluster_name}")
             raise

--- a/tests/mysql_shell/builders/test_quoting.py
+++ b/tests/mysql_shell/builders/test_quoting.py
@@ -3,7 +3,19 @@
 
 import pytest
 
-from mysql_shell.builders import QueryQuoter
+from mysql_shell.builders import ArgsQuoter, QueryQuoter
+
+
+@pytest.mark.unit
+class TestArgsQuoter:
+    """Class to group all the ArgsQuoter tests."""
+
+    def test_quote_value(self):
+        """Test the quote_value method."""
+        quoter = ArgsQuoter()
+
+        assert quoter.quote_value("test") == "'test'"
+        assert quoter.quote_value(100) == 100
 
 
 @pytest.mark.unit

--- a/tests/mysql_shell/clients/test_cluster.py
+++ b/tests/mysql_shell/clients/test_cluster.py
@@ -10,6 +10,7 @@ from helpers import (
     TEST_CLUSTER_NAME,
     build_local_executor,
 )
+from mysql_shell.builders import ArgsQuoter
 from mysql_shell.clients import ClusterClient
 from mysql_shell.executors import LocalExecutor
 
@@ -29,7 +30,7 @@ class TestClusterClient:
     @pytest.fixture(scope="class", autouse=True)
     def client(self, executor: LocalExecutor):
         """MySQL Cluster client fixture."""
-        return ClusterClient(executor)
+        return ClusterClient(executor, ArgsQuoter())
 
     @staticmethod
     def _get_member_address(client: ClusterClient) -> str:


### PR DESCRIPTION
This PR defines a new `update_router_within_cluster` method to the ClusterClient class.

This is the first MySQL Shell 8.4+ functionality (see 8.0 [API](https://dev.mysql.com/doc/dev/mysqlsh-api-javascript/8.0/classmysqlsh_1_1dba_1_1_cluster.html) vs 8.4 [API](https://dev.mysql.com/doc/dev/mysqlsh-api-javascript/8.4/classmysqlsh_1_1dba_1_1_cluster.html)), and it will allow us to tweak the MySQL Router config options, required to disable MySQL Router 8.2+ lack-of-quorum safety precautions, and offer the MySQL Router 8.4 in one MySQL Server instance setups.

### Additional changes:
- Defined a new `ArgsQuoter` class, to quote arguments going into Python function calls.