### PR TITLE
[MISC] Release v1.1.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,8 @@ jobs:
           gh release upload "${{ needs.build.outputs.VERSION }}" dist/*.{tar.gz,whl}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
 
   upload-pypi:
     name: "Publish to PyPI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 
 
 ## Unreleased
+
+## [1.1.0][changes-1.1.0] - 2026-06-08
 ### Added
 - Update router config to ClusterClient class.
 
@@ -127,5 +129,6 @@ The format is based on [Keep a Changelog][docs-changelog], and the version adher
 [changes-0.8.1]: https://github.com/canonical/mysql-shell-client/compare/0.8.0...0.8.1
 [changes-0.9.0]: https://github.com/canonical/mysql-shell-client/compare/0.8.1...0.9.0
 [changes-1.0.0]: https://github.com/canonical/mysql-shell-client/compare/0.9.0...1.0.0
+[changes-1.1.0]: https://github.com/canonical/mysql-shell-client/compare/1.0.0...1.1.0
 [docs-changelog]: https://keepachangelog.com/en/1.0.0/
 [docs-semver]: https://semver.org/spec/v2.0.0.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Python client for MySQL Shell"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 readme = "README.md"
-version = "1.0.0"
+version = "1.1.0"
 authors = [{ name = "Sinclert Perez", email = "sinclert.perez@canonical.com" }]
 maintainers = [{ name = "Canonical Data Platform", email = "data-platform@lists.launchpad.net" }]
 dependencies = []


### PR DESCRIPTION
This PR makes the necessary changes to release version 1.1.0.

It also fixes the lack of `content` permissions in the release GHA workflow, where if not specified, the default permissions (read) does not allow the creation of a GitHub tag (see failed [CI run](https://github.com/canonical/mysql-shell-client/actions/runs/26436767642)).